### PR TITLE
Enabling PEP 604 for older Python versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
   - id: black
     args: [--safe, --quiet, --line-length=100]
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.2.0
+  rev: v4.3.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
@@ -26,7 +26,7 @@ repos:
   hooks:
   - id: reorder-python-imports
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.32.0
+  rev: v2.34.0
   hooks:
   - id: pyupgrade
     args: [--py36-plus]

--- a/GooseBib/journals.py
+++ b/GooseBib/journals.py
@@ -17,6 +17,8 @@ In GooseBib, a journal database is stored as a YAML-file, for example:
 Note that the minimal requirement is to store the ``name``, the ``abbreviation``, ``acronym``,
 and ``variations`` are optional.
 """
+from __future__ import annotations
+
 import csv
 import io
 import os


### PR DESCRIPTION
Fixes https://github.com/tdegeus/GooseBib/issues/63