### PR TITLE
Removing underscore workaround

### DIFF
--- a/GooseBib/bibtex.py
+++ b/GooseBib/bibtex.py
@@ -760,7 +760,6 @@ def clean(
         # fix underscore problems
         # -
         if "doi" in entry:
-            entry["doi"] = entry["doi"].replace("_", r"\_")
             entry["doi"] = re.sub(r"[\{}]?[\\]+\_[\}]?", r"\\_", entry["doi"])
         # -
         if "url" in entry:


### PR DESCRIPTION
This was not the correct place to make this replacement. Rather, a suggested use is https://stackoverflow.com/a/57028315/2646505 . See also https://github.com/tdegeus/goose-article/commit/d0ce26d4d732d12771c916ee25d1f631066562fc